### PR TITLE
Fix boostrap.js

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,9 +1,8 @@
 const
 handlebars  = require('handlebars'),
 config      = require('./config'),
-log         = require('@superhero/debug').log
-
-addHelper(name, filename)
+log         = require('@superhero/debug').log,
+addHelper   = (name, filename) =>
 {
   let helper
   switch(typeof filename)

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,8 +1,9 @@
 const
 handlebars  = require('handlebars'),
 config      = require('./config'),
-log         = require('@superhero/debug').log,
-addHelper   = (name, filename) =>
+log         = require('@superhero/debug').log
+
+function addHelper(name, filename)
 {
   let helper
   switch(typeof filename)


### PR DESCRIPTION
Error:
/opt/main/node_modules/@superhero/core.handlebars/bootstrap.js:6
addHelper(name, filename)
^

ReferenceError: addHelper is not defined
    at Object.<anonymous> (/opt/main/node_modules/@superhero/core.handlebars/bootstrap.js:6:1)